### PR TITLE
Update jetty to latest to fix multiple CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   </modules>
   <properties>
     <jersey.version>2.27</jersey.version>
-    <jetty.version>9.4.15.v20190215</jetty.version>
+    <jetty.version>9.4.17.v20190418</jetty.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This newer version of jetty fixes:

* CVE-2019-10247
* CVE-2019-10246
* CVE-2019-10241